### PR TITLE
[Mellanox] Add new platform API to PsuBase to support PSU LED management

### DIFF
--- a/sonic_platform_base/psu_base.py
+++ b/sonic_platform_base/psu_base.py
@@ -128,3 +128,43 @@ class PsuBase(device_base.DeviceBase):
             A string, one of the predefined STATUS_LED_COLOR_* strings above
         """
         raise NotImplementedError
+
+    def get_temperature(self):
+        """
+        Retrieves current temperature reading from PSU
+
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125 
+        """
+        raise NotImplementedError
+
+    def get_temperature_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of PSU
+
+        Returns:
+            A float number, the high threshold temperature of PSU in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        raise NotImplementedError
+
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+
+        Returns:
+            A float number, the high threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+
+        Returns:
+            A float number, the low threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError


### PR DESCRIPTION
Add four new platform API to PsuBase:
1. get_temperature
2. get_temperature_high_threshold
3. get_voltage_high_threshold
4. get_voltage_low_threshold