### PR TITLE
[system led] Add platform API support for system LED and ASIC temperature

### DIFF
--- a/sonic_platform_base/chassis_base.py
+++ b/sonic_platform_base/chassis_base.py
@@ -387,6 +387,26 @@ class ChassisBase(device_base.DeviceBase):
         """
         raise NotImplementedError
 
+    def get_asic_temperature(self):
+        """
+        Retrieves current temperature reading from ASIC sensor
+
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125 
+        """
+        raise NotImplementedError
+
+    def get_asic_temperature_threshold(self):
+        """
+        Retrieves the high threshold temperature of ASIC
+
+        Returns:
+            A float number, the high threshold temperature of ASIC in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        raise NotImplementedError
+
     ##############################################
     # SFP methods
     ##############################################
@@ -432,6 +452,33 @@ class ChassisBase(device_base.DeviceBase):
                              index, len(self._sfp_list)-1))
 
         return sfp
+
+    ##############################################
+    # System LED methods
+    ##############################################
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the system LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   system LED
+
+        Returns:
+            bool: True if system LED state is set successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_status_led(self):
+        """
+        Gets the state of the system LED
+
+        Returns:
+            A string, one of the valid LED color strings which could be vendor
+            specified.
+        """
+        raise NotImplementedError
 
     ##############################################
     # Other methods


### PR DESCRIPTION
Why I did this?

To support system health feature, we need get/set system LED status and get ASIC temperature.

How I did this?

Add 4 new platform API to chassis_base.py for vendor to implement:
- get_asic_temperature
- get_asic_temperature_threshold
- set_status_led
- get_status_led