### PR TITLE
[eeprom_tlvinfo] Fix issue: read data from eeprom should trim tail \0

### DIFF
--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -436,7 +436,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                 return (False, None)
             if ord(e[tlv_index]) == code:
                 return (True, [ord(e[tlv_index]), ord(e[tlv_index+1]), \
-                               e[tlv_index+2:tlv_index+2+ord(e[tlv_index+1])]].strip('\0'))
+                               e[tlv_index+2:tlv_index+2+ord(e[tlv_index+1])].strip('\0')])
             tlv_index += ord(e[tlv_index+1]) + 2
         return (False, None)
 

--- a/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
+++ b/sonic_platform_base/sonic_eeprom/eeprom_tlvinfo.py
@@ -436,7 +436,7 @@ class TlvInfoDecoder(eeprom_base.EepromDecoder):
                 return (False, None)
             if ord(e[tlv_index]) == code:
                 return (True, [ord(e[tlv_index]), ord(e[tlv_index+1]), \
-                               e[tlv_index+2:tlv_index+2+ord(e[tlv_index+1])]])
+                               e[tlv_index+2:tlv_index+2+ord(e[tlv_index+1])]].strip('\0'))
             tlv_index += ord(e[tlv_index+1]) + 2
         return (False, None)
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

Now we are reading base mac, product name from eeprom data, and the data read from eeprom contains multiple "\0" characters at the end, need trim them to make the string clean and display correct.

**- How I did it**

Strip all "\0" for the data read from eeprom

**- How to verify it**

Manual test

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [x] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
