### PR TITLE
[y_cable] Skip ImportError in y_cable.py

### DIFF
--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -6,10 +6,8 @@
 
 try:
     import struct
-
-    import sonic_platform.platform
     from sonic_py_common import logger
-
+    import sonic_platform.platform
 except ImportError as e:
     # When build python3 xcvrd, it tries to do basic check which will import this file. However,
     # not all platform supports python3 API now, so it could cause an issue when importing 

--- a/sonic_y_cable/y_cable.py
+++ b/sonic_y_cable/y_cable.py
@@ -11,7 +11,13 @@ try:
     from sonic_py_common import logger
 
 except ImportError as e:
-    raise ImportError(str(e) + " - required module not found")
+    # When build python3 xcvrd, it tries to do basic check which will import this file. However,
+    # not all platform supports python3 API now, so it could cause an issue when importing 
+    # sonic_platform.platform. We skip the ImportError here. This is safe because:
+    #   1. If any python package is not available, there will be exception when use it
+    #   2. Vendors know their platform API version, they are responsible to use correct python
+    #   version when importing this file.
+    pass
 
 # definitions of the offset with width accomodated for values
 # of MUX register specs of upper page 0x04 starting at 640


### PR DESCRIPTION
Why I did this?

When build python3 xcvrd, it tries to do basic check which will import this y_cable.py. However, not all platform supports python3 API now, so it could cause an issue when importing sonic_platform.platform. See error:

```
10:03:13  Modified dependencies are : [sonic_py_common-1.0-py3-none-any.whl sonic_xcvrd-1.0-py2-none-any.whl sonic_platform_common-1.0-py3-none-any.whl  M  rules/sonic-xcvrd.dep M  rules/sonic-xcvrd.mk M  slave.mk M  sonic-slave-buster/Dockerfile.j2   M  setup.py M  xcvrd/xcvrd.py M  xcvrd/xcvrd_utilities/y_cable_helper.py ] 
10:03:13  /sonic/src/sonic-platform-daemons/sonic-xcvrd /sonic
10:03:13  running test
10:03:13  WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
10:03:13  running egg_info
10:03:13  writing sonic_xcvrd.egg-info/PKG-INFO
10:03:13  writing dependency_links to sonic_xcvrd.egg-info/dependency_links.txt
10:03:13  writing entry points to sonic_xcvrd.egg-info/entry_points.txt
10:03:13  writing requirements to sonic_xcvrd.egg-info/requires.txt
10:03:13  writing top-level names to sonic_xcvrd.egg-info/top_level.txt
10:03:13  reading manifest file 'sonic_xcvrd.egg-info/SOURCES.txt'
10:03:13  writing manifest file 'sonic_xcvrd.egg-info/SOURCES.txt'
10:03:13  running build_ext
10:03:13  xcvrd (unittest.loader._FailedTest) ... ERROR
10:03:13  y_cable_helper (unittest.loader._FailedTest) ... ERROR
10:03:13  
10:03:13  ======================================================================
10:03:13  ERROR: xcvrd (unittest.loader._FailedTest)
10:03:13  ----------------------------------------------------------------------
10:03:13  ImportError: Failed to import test module: xcvrd
10:03:13  Traceback (most recent call last):
10:03:13    File "/usr/local/lib/python3.7/dist-packages/sonic_y_cable/y_cable.py", line 10, in <module>
10:03:13      import sonic_platform.platform
10:03:13  ModuleNotFoundError: No module named 'sonic_platform'
10:03:13  
10:03:13  During handling of the above exception, another exception occurred:
10:03:13  
10:03:13  Traceback (most recent call last):
10:03:13    File "/sonic/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py", line 11, in <module>
10:03:13      from sonic_y_cable import y_cable
10:03:13    File "/usr/local/lib/python3.7/dist-packages/sonic_y_cable/y_cable.py", line 14, in <module>
10:03:13      raise ImportError(str(e) + " - required module not found")
10:03:13  ImportError: No module named 'sonic_platform' - required module not found
10:03:13  
10:03:13  During handling of the above exception, another exception occurred:
10:03:13  
10:03:13  Traceback (most recent call last):
10:03:13    File "/sonic/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py", line 24, in <module>
10:03:13      from .xcvrd_utilities import y_cable_helper
10:03:13    File "/sonic/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py", line 14, in <module>
10:03:13      raise ImportError(str(e) + " - required module not found")
10:03:13  ImportError: No module named 'sonic_platform' - required module not found - required module not found
10:03:13  
10:03:13  During handling of the above exception, another exception occurred:
10:03:13  
10:03:13  Traceback (most recent call last):
10:03:13    File "/usr/lib/python3.7/unittest/loader.py", line 154, in loadTestsFromName
10:03:13      module = __import__(module_name)
10:03:13    File "/sonic/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd.py", line 26, in <module>
10:03:13      raise ImportError (str(e) + " - required module not found")
10:03:13  ImportError: No module named 'sonic_platform' - required module not found - required module not found - required module not found
10:03:13  
10:03:13  
10:03:13  ======================================================================
10:03:13  ERROR: y_cable_helper (unittest.loader._FailedTest)
10:03:13  ----------------------------------------------------------------------
10:03:13  ImportError: Failed to import test module: y_cable_helper
10:03:13  Traceback (most recent call last):
10:03:13    File "/usr/local/lib/python3.7/dist-packages/sonic_y_cable/y_cable.py", line 10, in <module>
10:03:13      import sonic_platform.platform
10:03:13  ModuleNotFoundError: No module named 'sonic_platform'
10:03:13  
10:03:13  During handling of the above exception, another exception occurred:
10:03:13  
10:03:13  Traceback (most recent call last):
10:03:13    File "/sonic/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py", line 11, in <module>
10:03:13      from sonic_y_cable import y_cable
10:03:13    File "/usr/local/lib/python3.7/dist-packages/sonic_y_cable/y_cable.py", line 14, in <module>
10:03:13      raise ImportError(str(e) + " - required module not found")
10:03:13  ImportError: No module named 'sonic_platform' - required module not found
10:03:13  
10:03:13  During handling of the above exception, another exception occurred:
10:03:13  
10:03:13  Traceback (most recent call last):
10:03:13    File "/usr/lib/python3.7/unittest/loader.py", line 154, in loadTestsFromName
10:03:13      module = __import__(module_name)
10:03:13    File "/sonic/src/sonic-platform-daemons/sonic-xcvrd/xcvrd/xcvrd_utilities/y_cable_helper.py", line 14, in <module>
10:03:13      raise ImportError(str(e) + " - required module not found")
10:03:13  ImportError: No module named 'sonic_platform' - required module not found - required module not found
10:03:13  
10:03:13  
10:03:13  ----------------------------------------------------------------------
10:03:13  Ran 2 tests in 0.000s

```

We skip the ImportError here to make the builder happy. And this is safe because:

1. If any python package is not available, there will be exception when use it
2. Vendors know their platform API version, they are responsible to use correct python version when importing this file.

How I did this?

Skip the ImportError.

How I verify this?

Run build.
