### PR TITLE
[202012] Fix issue: sff8436 does not support decoding power class 5~7

### DIFF
--- a/sonic_platform_base/sonic_sfp/sff8436.py
+++ b/sonic_platform_base/sonic_sfp/sff8436.py
@@ -249,6 +249,15 @@ class sff8436InterfaceId(sffbase):
             'd7': 'Power Class 7(5.0W max), CLEI present, CDR present in Rx',
             'db': 'Power Class 7(5.0W max), CLEI present, CDR present in Tx',
             'df': 'Power Class 7(5.0W max), CLEI present, CDR present in Rx Tx',
+
+            '20': 'Power Class 8',
+            '24': 'Power Class 8, CDR present in Rx',
+            '28': 'Power Class 8, CDR present in Tx',
+            '2c': 'Power Class 8, CDR present in Rx Tx',
+            '30': 'Power Class 8, CLEI present',
+            '34': 'Power Class 8, CLEI present, CDR present in Rx',
+            '38': 'Power Class 8, CLEI present, CDR present in Tx',
+            '3c': 'Power Class 8, CLEI present, CDR present in Rx Tx',
             }
 
     connector = {

--- a/sonic_platform_base/sonic_sfp/sff8436.py
+++ b/sonic_platform_base/sonic_sfp/sff8436.py
@@ -221,7 +221,34 @@ class sff8436InterfaceId(sffbase):
             'd0': 'Power Class 4(3.5W max), CLEI present',
             'd4': 'Power Class 4(3.5W max), CLEI present, CDR present in Rx',
             'd8': 'Power Class 4(3.5W max), CLEI present, CDR present in Tx',
-            'dc': 'Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx'
+            'dc': 'Power Class 4(3.5W max), CLEI present, CDR present in Rx Tx',
+
+            'c1': 'Power Class 5(4.0W max)',
+            'c5': 'Power Class 5(4.0W max), CDR present in Rx',
+            'c9': 'Power Class 5(4.0W max), CDR present in Tx',
+            'cd': 'Power Class 5(4.0W max), CDR present in Rx Tx',
+            'd1': 'Power Class 5(4.0W max), CLEI present',
+            'd5': 'Power Class 5(4.0W max), CLEI present, CDR present in Rx',
+            'd9': 'Power Class 5(4.0W max), CLEI present, CDR present in Tx',
+            'dd': 'Power Class 5(4.0W max), CLEI present, CDR present in Rx Tx',
+
+            'c2': 'Power Class 6(4.5W max)',
+            'c6': 'Power Class 6(4.5W max), CDR present in Rx',
+            'ca': 'Power Class 6(4.5W max), CDR present in Tx',
+            'ce': 'Power Class 6(4.5W max), CDR present in Rx Tx',
+            'd2': 'Power Class 6(4.5W max), CLEI present',
+            'd6': 'Power Class 6(4.5W max), CLEI present, CDR present in Rx',
+            'da': 'Power Class 6(4.5W max), CLEI present, CDR present in Tx',
+            'de': 'Power Class 6(4.5W max), CLEI present, CDR present in Rx Tx',
+
+            'c3': 'Power Class 7(5.0W max)',
+            'c7': 'Power Class 7(5.0W max), CDR present in Rx',
+            'cb': 'Power Class 7(5.0W max), CDR present in Tx',
+            'cf': 'Power Class 7(5.0W max), CDR present in Rx Tx',
+            'd3': 'Power Class 7(5.0W max), CLEI present',
+            'd7': 'Power Class 7(5.0W max), CLEI present, CDR present in Rx',
+            'db': 'Power Class 7(5.0W max), CLEI present, CDR present in Tx',
+            'df': 'Power Class 7(5.0W max), CLEI present, CDR present in Rx Tx',
             }
 
     connector = {
@@ -346,7 +373,7 @@ class sff8436InterfaceId(sffbase):
                  'size'  : 1,
                  'type'  : 'bitmap',
                  'decode': {}}}
-    
+
     sfp_info_bulk = {'type':
                 {'offset':0,
                  'size':1,
@@ -406,7 +433,7 @@ class sff8436InterfaceId(sffbase):
                 'size':1,
                  'type':'int'}
     }
-    
+
     vendor_name = {
         'Vendor Name':
             {'offset': 0,
@@ -441,7 +468,7 @@ class sff8436InterfaceId(sffbase):
                  'size':3,
                  'type' : 'hex'}
         }
-    
+
     vendor_date = {
         'VendorDataCode(YYYY-MM-DD Lot)':
                 {'offset':0,
@@ -1066,7 +1093,7 @@ class sff8436Dom(sffbase):
                  'size':2,
                  'type': 'func',
                  'decode': { 'func':calc_temperature}},
-            'Vcc':   
+            'Vcc':
                 {'offset':26,
                  'size':2,
                  'type': 'func',


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
Support decoding power class 5~7 for sff8436

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
`show interfaces transceiver eeprom -d` displays Unknown power class for cables who support power class 5~7. The PR is aimed to fix it.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual test.

#### Additional Information (Optional)

