### PR TITLE
[sonic-platform-common] catch exception while creating api object

### DIFF
--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -128,5 +128,9 @@ class XcvrApiFactory(object):
         if id in id_mapping:
             func, args = id_mapping[id]
             if isinstance(args, tuple):
-                return func(*args)
+                try:
+                    return func(*args)
+                except Exception as e:
+                    print(f"Error creating API: {e}")
+                    return None
         return None

--- a/tests/sonic_xcvr/test_xcvr_api_factory.py
+++ b/tests/sonic_xcvr/test_xcvr_api_factory.py
@@ -73,6 +73,15 @@ class TestXcvrApiFactory(object):
         self.api.reader = reader
         api = self.api.create_xcvr_api()
         assert isinstance(api, expected_api)
+        
+    @patch('sonic_platform_base.sonic_xcvr.xcvr_api_factory.XcvrApiFactory._create_api', MagicMock(side_effect=Exception('')))
+    def test_create_xcvr_api_with_exception(self):
+        self.api.reader = self.mock_reader
+        CmisCodes = MagicMock()
+        CmisMemMap = MagicMock()
+        XcvrEeprom = MagicMock()
+        CmisFr800gApi = MagicMock()
+        assert self.api.create_xcvr_api() is None
 
 class TestAmphBackplaneImpl:
     @pytest.fixture


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
`XcvrApiFactory.create_xcvr_api` may raise exception (e.g. the EEPROM is corrupted which has non unicode character). The exception would cause xcvrd crash. The PR is to catch the exception so that  `XcvrApiFactory.create_xcvr_api` either return a None or a valid API object

#### Motivation and Context
When there is invalid character in module EEPROM, it would crash xcvrd and affect other healthy modules. The PR catches the exception in `XcvrApiFactory.create_xcvr_api` to prevent it affecting other modules.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
unit test
manual test

#### Additional Information (Optional)

