### PR TITLE
[cmis] Only create CdbFwHandler if module support CDB

### DIFF
--- a/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
+++ b/sonic_platform_base/sonic_xcvr/api/public/c_cmis.py
@@ -55,8 +55,8 @@ C_CMIS_XCVR_INFO_DEFAULT_DICT.update({
 })
 
 class CCmisApi(CmisApi):
-    def __init__(self, xcvr_eeprom, cdb):
-        super(CCmisApi, self).__init__(xcvr_eeprom, cdb)
+    def __init__(self, xcvr_eeprom, init_cdb=False):
+        super(CCmisApi, self).__init__(xcvr_eeprom, init_cdb)
 
     def _get_vdm_key_to_db_prefix_map(self):
         combined_map = {**CMIS_VDM_KEY_TO_DB_PREFIX_KEY_MAP, **C_CMIS_DELTA_VDM_KEY_TO_DB_PREFIX_KEY_MAP}

--- a/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
+++ b/sonic_platform_base/sonic_xcvr/xcvr_api_factory.py
@@ -12,9 +12,6 @@ from .api.public.cmis import CmisApi
 from .api.public.c_cmis import CCmisApi
 from .mem_maps.public.cmis import CmisMemMap
 from .mem_maps.public.c_cmis import CCmisMemMap
-from .mem_maps.public.cdb import CdbMemMap
-from .cdb.cdb_fw import CdbFwHandler as CdbFw
-from .codes.public.cdb import CdbCodes
 
 from .codes.credo.aec_800g import CmisAec800gCodes
 from .api.credo.aec_800g import CmisAec800gApi
@@ -89,13 +86,11 @@ class XcvrApiFactory(object):
              ('EOPTOLINK' in vendor_name and vendor_pn in EOP_800G_VENDOR_PN_LIST):
             api = self._create_api(CmisCodes, CmisMemMap, CmisFr800gApi)
         else:
-            cdb_mem_map = CdbMemMap(CdbCodes)
-            cdb_fw = CdbFw(self.reader, self.writer, cdb_mem_map)
             xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CmisMemMap(CmisCodes))
-            api = CmisApi(xcvr_eeprom, cdb_fw)
+            api = CmisApi(xcvr_eeprom, init_cdb=True)
             if api.is_coherent_module():
                 xcvr_eeprom = XcvrEeprom(self.reader, self.writer, CCmisMemMap(CmisCodes))
-                api = CCmisApi(xcvr_eeprom, cdb_fw)
+                api = CCmisApi(xcvr_eeprom, init_cdb=True)
         return api
 
     def _create_qsfp_api(self):

--- a/tests/sonic_xcvr/test_ccmis.py
+++ b/tests/sonic_xcvr/test_ccmis.py
@@ -3,14 +3,9 @@ from mock import patch
 import pytest
 from sonic_platform_base.sonic_xcvr.api.public.c_cmis import CCmisApi, C_CMIS_XCVR_INFO_DEFAULT_DICT
 from sonic_platform_base.sonic_xcvr.mem_maps.public.c_cmis import CCmisMemMap
-from sonic_platform_base.sonic_xcvr.mem_maps.public.cdb import CdbMemMap
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom
 from sonic_platform_base.sonic_xcvr.codes.public.cmis import CmisCodes
-from sonic_platform_base.sonic_xcvr.codes.public.cdb import CdbCodes
-from sonic_platform_base.sonic_xcvr.cdb.cdb_fw import CdbFwHandler as CdbFw
 
-
-CdbFw.initFwHandler = MagicMock(return_value=True)
 
 class TestCCmis(object):
     codes = CmisCodes
@@ -19,8 +14,7 @@ class TestCCmis(object):
     writer = MagicMock()
     eeprom = XcvrEeprom(reader, writer, mem_map)
 
-    cdb = CdbFw(reader, writer, CdbMemMap(CdbCodes))
-    api = CCmisApi(eeprom, cdb)
+    api = CCmisApi(eeprom, init_cdb=False)
 
     @pytest.mark.parametrize("mock_response, expected", [
         (8, 150),

--- a/tests/sonic_xcvr/test_cdb_fw.py
+++ b/tests/sonic_xcvr/test_cdb_fw.py
@@ -59,7 +59,7 @@ class TestCdbFwHandler:
         
         result = handler.initFwHandler()
         
-        assert result == True
+        assert result == False
 
     def test_initFwHandler_read_reply_none(self):
         """Test initFwHandler when read_reply returns None"""
@@ -75,7 +75,7 @@ class TestCdbFwHandler:
         
         result = handler.initFwHandler()
 
-        assert result == True
+        assert result == False
 
     def test_initFwHandler_lpl_only(self):
         """Test initFwHandler with LPL only mechanism"""

--- a/tests/sonic_xcvr/test_sfp_optoe_base.py
+++ b/tests/sonic_xcvr/test_sfp_optoe_base.py
@@ -9,11 +9,8 @@ from sonic_platform_base.sonic_xcvr.mem_maps.public.c_cmis import CCmisMemMap
 from sonic_platform_base.sonic_xcvr.xcvr_eeprom import XcvrEeprom 
 from sonic_platform_base.sonic_xcvr.codes.public.cmis import CmisCodes 
 from sonic_platform_base.sonic_xcvr.api.public.sff8472 import Sff8472Api
-from sonic_platform_base.sonic_xcvr.mem_maps.public.cdb import CdbMemMap
-from sonic_platform_base.sonic_xcvr.codes.public.cdb import CdbCodes
-from sonic_platform_base.sonic_xcvr.cdb.cdb_fw import CdbFwHandler as CdbFw
 
-CdbFw.initFwHandler = MagicMock(return_value=True)
+
 class TestSfpOptoeBase(object): 
  
     codes = CmisCodes 
@@ -22,9 +19,8 @@ class TestSfpOptoeBase(object):
     writer = MagicMock() 
     eeprom = XcvrEeprom(reader, writer, mem_map) 
     sfp_optoe_api = SfpOptoeBase() 
-    cdb = CdbFw(reader, writer, CdbMemMap(CdbCodes))
-    ccmis_api = CCmisApi(eeprom, cdb) 
-    cmis_api = CmisApi(eeprom, cdb) 
+    ccmis_api = CCmisApi(eeprom, init_cdb=False) 
+    cmis_api = CmisApi(eeprom, init_cdb=False) 
     sff8472_api = Sff8472Api(eeprom)
  
     def test_is_transceiver_vdm_supported_non_cmis(self):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
CdbFwHandler is created to handle CDB related command for cmis module. It should be created only CDB is supported by this module. However, the current implementation add an assertion in __init__ function which will fail any cmis module which does not support CDB:

```
class CdbFwHandler(CdbCmdHandler):
    def __init__(self, reader, writer, mem_map):
        super(CdbFwHandler, self).__init__(reader, writer, mem_map)
        self.start_payload_size = 0
        self.is_lpl_only = False
        self.rw_length_ext = 0
        assert True == self.initFwHandler(), "Failed to initialize firmware handler"
```

The error logs:
```
2025 Nov 16 12:21:21.010105 sonic INFO pmon#supervisord: xcvrd Error creating API: Failed to initialize firmware handler
2025 Nov 16 12:21:21.010182 sonic INFO pmon#supervisord: xcvrd Failed to get firmware management features
```

#### Motivation and Context
Only create CdbFwHandler if module support CDB


#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Manual test with modules that support and not support CDB
Unit test

#### Additional Information (Optional)

